### PR TITLE
feat(ui): overhaul dashboard, upload wizard, and file upload component

### DIFF
--- a/frontend/src/components/FileUpload/FileUpload.module.scss
+++ b/frontend/src/components/FileUpload/FileUpload.module.scss
@@ -1,5 +1,37 @@
 .fileUpload {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
+  &__dropzone {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-6) var(--space-5);
+    border: 2px dashed #d1d5db;
+    border-radius: var(--radius-2);
+    background: #fafafa;
+    text-align: center;
+    transition: border-color 0.15s;
+
+    &:hover {
+      border-color: #9ca3af;
+    }
+  }
+
+  &__icon {
+    width: 40px;
+    height: 40px;
+    color: #9ca3af;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  &__hint {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-muted);
+  }
 }

--- a/frontend/src/components/FileUpload/FileUpload.tsx
+++ b/frontend/src/components/FileUpload/FileUpload.tsx
@@ -51,20 +51,36 @@ function FileUpload({ onUploaded }: Props) {
         return;
       }
       onUploaded(id);
+      toast.success('File uploaded successfully!', { duration: 2000 });
     } catch (err: unknown) {
       if (err instanceof Error) {
         toast.error(err?.message || 'Upload failed');
       }
-    } finally {
-      toast.success('File uploaded successfully!', { duration: 2000 });
     }
   }
 
   return (
     <div className={styles.fileUpload}>
-      <Button accept=".csv,.xls,.xlsx" buttonStyle="default" onFileChange={handleChange}>
-        Upload file
-      </Button>
+      <div className={styles.fileUpload__dropzone}>
+        <svg
+          className={styles.fileUpload__icon}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 16V4m0 0L8 8m4-4 4 4" />
+          <path d="M20 16.5A3.5 3.5 0 0 1 16.5 20h-9A3.5 3.5 0 0 1 4 16.5" />
+        </svg>
+        <p className={styles.fileUpload__title}>Upload your dataset</p>
+        <p className={styles.fileUpload__hint}>CSV, XLS, or XLSX files are supported.</p>
+        <Button accept=".csv,.xls,.xlsx" buttonStyle="default" onFileChange={handleChange}>
+          Choose file
+        </Button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard/Dashboard.module.scss
+++ b/frontend/src/pages/Dashboard/Dashboard.module.scss
@@ -1,120 +1,275 @@
 .dashboard {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  padding: var(--space-4);
-}
+  padding: var(--space-5) 0;
 
-.metrics {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--space-3);
-
-  @media (max-width: 900px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  &__container {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
   }
-  @media (max-width: 520px) {
-    grid-template-columns: 1fr;
-  }
-}
 
-.tableSection {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
+  // ── Page header ────────────────────────────────────────
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
 
   &__title {
     margin: 0;
-    font-size: 1.1rem;
-  }
-}
-
-.tableWrap {
-  overflow-x: auto;
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  background: var(--color-surface);
-  border: 1px solid var(--color-muted);
-  border-radius: var(--radius-1);
-  box-shadow: var(--shadow-1);
-
-  th,
-  td {
-    padding: 10px 12px;
-    border-bottom: 1px solid #e5e7eb;
-    text-align: left;
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1.2;
+    color: var(--color-text);
   }
 
-  thead th {
-    font-weight: 600;
+  &__subtitle {
+    margin: 0;
+    font-size: 0.9375rem;
     color: var(--color-muted);
-    background: #f9fafb;
+    line-height: 1.5;
   }
 
-  tbody tr:last-child td {
-    border-bottom: none;
-  }
-
-  &__empty {
+  // ── Loading / error states ─────────────────────────────
+  &__state {
+    background: var(--color-surface);
+    border: 1px solid #e5e7eb;
+    border-radius: var(--radius-2);
+    padding: var(--space-6) var(--space-5);
     text-align: center;
     color: var(--color-muted);
-    padding: 16px;
-  }
-}
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 
-/* --- pagination (new) --- */
-.pager {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  margin-top: var(--space-2);
-
-  &__stats {
-    color: var(--color-muted);
-    font-size: 0.9rem;
-
-    strong {
-      color: inherit;
+    &--error {
+      background: #fef2f2;
+      border-color: #fecaca;
+      color: var(--color-danger);
     }
   }
 
-  &__controls {
+  &__stateText {
+    margin: 0;
+    font-size: 0.9375rem;
+  }
+
+  // ── Metrics grid ───────────────────────────────────────
+  &__metrics {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--space-3);
+
+    @media (max-width: 900px) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    @media (max-width: 520px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  // ── Table card ─────────────────────────────────────────
+  &__tableCard {
+    background: var(--color-surface);
+    border: 1px solid #e5e7eb;
+    border-radius: var(--radius-2);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__tableTitle {
+    margin: 0;
+    padding: var(--space-4) var(--space-5);
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+    border-bottom: 1px solid #f3f4f6;
+  }
+
+  &__tableWrap {
+    overflow-x: auto;
+  }
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+
+    th,
+    td {
+      padding: 11px var(--space-5);
+      border-bottom: 1px solid #f3f4f6;
+      font-size: 0.875rem;
+      text-align: left;
+    }
+
+    // right-align all columns except the first (Stack name)
+    th:nth-child(n + 2),
+    td:nth-child(n + 2) {
+      text-align: right;
+    }
+
+    thead th {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--color-muted);
+      background: #f9fafb;
+      border-bottom: 1px solid #e5e7eb;
+      padding: 0;
+
+      &:hover {
+        background: #f3f4f6;
+      }
+    }
+
+    tbody tr {
+      transition: background 0.1s;
+
+      &:hover {
+        background: #f9fafb;
+      }
+
+      &:last-child td {
+        border-bottom: none;
+      }
+
+      &:nth-child(even) {
+        background: #fafafa;
+
+        &:hover {
+          background: #f3f4f6;
+        }
+      }
+    }
+  }
+
+  // ── Sort buttons ───────────────────────────────────────
+  &__sortButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 5px;
+    width: 100%;
+    padding: 11px var(--space-5);
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: inherit;
+    transition: color 0.1s;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: -2px;
+    }
+
+    &--right {
+      justify-content: flex-end;
+    }
+  }
+
+  &__sortIcon {
+    font-size: 0.7rem;
+    line-height: 1;
+    color: var(--color-text);
+
+    &--inactive {
+      color: #d1d5db;
+    }
+  }
+
+  &__tableEmpty {
+    text-align: center !important;
+    color: var(--color-muted);
+    padding: var(--space-6) var(--space-4) !important;
+    font-size: 0.9rem;
+  }
+
+  // ── Pagination footer ──────────────────────────────────
+  &__pager {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-5);
+    border-top: 1px solid #f3f4f6;
+    background: #fafafa;
+
+    @media (max-width: 600px) {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+
+  &__pagerStats {
+    color: var(--color-muted);
+    font-size: 0.8125rem;
+
+    strong {
+      color: var(--color-text);
+      font-weight: 600;
+    }
+  }
+
+  &__pagerControls {
     display: flex;
     align-items: center;
     gap: var(--space-2);
   }
 
-  &__btn {
-    padding: 6px 10px;
-    border: 1px solid var(--color-muted);
-    background: var(--color-bg);
+  &__pagerBtn {
+    padding: 5px 10px;
+    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
     border-radius: var(--radius-1);
     cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    transition: background 0.1s, border-color 0.1s;
+
+    &:hover:not(:disabled) {
+      background: #f3f4f6;
+      border-color: #d1d5db;
+    }
 
     &:disabled {
-      opacity: 0.5;
+      opacity: 0.4;
       cursor: not-allowed;
     }
   }
 
-  &__page {
+  &__pagerPage {
     color: var(--color-muted);
+    font-size: 0.8125rem;
+    min-width: 52px;
+    text-align: center;
   }
 
-  &__size {
+  &__pagerSize {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
+    font-size: 0.8125rem;
+    color: var(--color-muted);
 
     select {
       padding: 4px 6px;
-      border: 1px solid var(--color-muted);
-      background: var(--color-bg);
+      border: 1px solid #e5e7eb;
+      background: var(--color-surface);
       border-radius: var(--radius-1);
+      font-size: 0.8125rem;
+      cursor: pointer;
+
+      &:focus {
+        outline: none;
+        border-color: var(--color-primary);
+      }
     }
   }
 }

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -11,11 +11,24 @@ import { fmtInt, fmtNumber } from '../../lib/format';
 
 const PAGE_SIZES = [10, 25, 50, 100];
 
+type SortKey = 'stack' | 'p50' | 'n';
+type SortDir = 'asc' | 'desc';
+
+const DEFAULT_SORT_DIR: Record<SortKey, SortDir> = {
+  stack: 'asc',
+  p50: 'desc',
+  n: 'desc',
+};
+
 function Dashboard() {
   const [summary, setSummary] = useState<SalarySummary | null>(null);
   const [stacks, setStacks] = useState<StackCompareRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // sort state — default: p50 descending
+  const [sortKey, setSortKey] = useState<SortKey>('p50');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
 
   // pagination state
   const [page, setPage] = useState(1);
@@ -42,115 +55,192 @@ function Dashboard() {
     return () => ctrl.abort();
   }, []);
 
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(DEFAULT_SORT_DIR[key]);
+    }
+    setPage(1);
+  }
+
   // reset to first page when data or pageSize changes
   useEffect(() => {
     setPage(1);
   }, [stacks, pageSize]);
+
+  const sortedRows = useMemo(() => {
+    return [...stacks].sort((a, b) => {
+      const cmp = sortKey === 'stack' ? a.stack.localeCompare(b.stack) : a[sortKey] - b[sortKey];
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [stacks, sortKey, sortDir]);
 
   const total = stacks.length;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const startIdx = (page - 1) * pageSize;
   const endIdx = Math.min(total, startIdx + pageSize);
 
-  const pageRows = useMemo(() => stacks.slice(startIdx, endIdx), [stacks, startIdx, endIdx]);
+  const pageRows = useMemo(
+    () => sortedRows.slice(startIdx, endIdx),
+    [sortedRows, startIdx, endIdx],
+  );
 
   const canPrev = page > 1;
   const canNext = page < totalPages;
 
   return (
     <div className={styles.dashboard}>
-      <h2>Analytics</h2>
+      <div className={styles.dashboard__container}>
+        <header className={styles.dashboard__header}>
+          <h2 className={styles.dashboard__title}>Analytics Dashboard</h2>
+          <p className={styles.dashboard__subtitle}>
+            Review salary distribution metrics and compare compensation by technology stack.
+          </p>
+        </header>
 
-      {!loading && !error && (
-        <>
-          <section className={styles.metrics} aria-label="Summary metrics">
-            <Metric label="p50" value={summary ? fmtNumber(summary.p50, 0) : '-'} />
-            <Metric label="p75" value={summary ? fmtNumber(summary.p75, 0) : '-'} />
-            <Metric label="p90" value={summary ? fmtNumber(summary.p90, 0) : '-'} />
-            <Metric label="n" value={summary ? fmtInt(summary.n) : '-'} />
-          </section>
+        {loading && (
+          <div className={styles.dashboard__state}>
+            <p className={styles.dashboard__stateText}>Loading analytics data…</p>
+          </div>
+        )}
 
-          <section className={styles.tableSection} aria-label="Stack comparison">
-            <h3 className={styles.tableSection__title}>Stack comparison (p50)</h3>
+        {!loading && error && (
+          <div className={`${styles.dashboard__state} ${styles['dashboard__state--error']}`}>
+            <p className={styles.dashboard__stateText}>{error}</p>
+          </div>
+        )}
 
-            <div className={styles.tableWrap}>
-              <table className={styles.table}>
-                <thead>
-                  <tr>
-                    <th>Stack</th>
-                    <th>p50</th>
-                    <th>n</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {pageRows.map((r, i) => (
-                    <tr key={`${r.stack}-${startIdx + i}`}>
-                      <td>{r.stack}</td>
-                      <td>{fmtNumber(r.p50, 0)}</td>
-                      <td>{fmtInt(r.n)}</td>
-                    </tr>
-                  ))}
+        {!loading && !error && (
+          <>
+            <section className={styles.dashboard__metrics} aria-label="Summary metrics">
+              <Metric label="Median salary" value={summary ? fmtNumber(summary.p50, 0) : '-'} />
+              <Metric label="75th percentile" value={summary ? fmtNumber(summary.p75, 0) : '-'} />
+              <Metric label="90th percentile" value={summary ? fmtNumber(summary.p90, 0) : '-'} />
+              <Metric label="Records analyzed" value={summary ? fmtInt(summary.n) : '-'} />
+            </section>
 
-                  {total === 0 && (
+            <section className={styles.dashboard__tableCard} aria-label="Stack comparison">
+              <h3 className={styles.dashboard__tableTitle}>Stack comparison</h3>
+
+              <div className={styles.dashboard__tableWrap}>
+                <table className={styles.dashboard__table}>
+                  <thead>
                     <tr>
-                      <td colSpan={3} className={styles.table__empty}>
-                        No data
-                      </td>
+                      {(
+                        [
+                          { key: 'stack', label: 'Stack' },
+                          { key: 'p50', label: 'Median (p50)' },
+                          { key: 'n', label: 'Records' },
+                        ] as { key: SortKey; label: string }[]
+                      ).map(({ key, label }) => {
+                        const isActive = sortKey === key;
+                        const ariaSort = isActive
+                          ? sortDir === 'asc'
+                            ? 'ascending'
+                            : 'descending'
+                          : 'none';
+                        return (
+                          <th key={key} aria-sort={ariaSort}>
+                            <button
+                              type="button"
+                              className={[
+                                styles.dashboard__sortButton,
+                                key !== 'stack' ? styles['dashboard__sortButton--right'] : '',
+                              ]
+                                .filter(Boolean)
+                                .join(' ')}
+                              onClick={() => handleSort(key)}
+                            >
+                              {label}
+                              <span
+                                className={[
+                                  styles.dashboard__sortIcon,
+                                  !isActive ? styles['dashboard__sortIcon--inactive'] : '',
+                                ]
+                                  .filter(Boolean)
+                                  .join(' ')}
+                                aria-hidden="true"
+                              >
+                                {!isActive ? '↕' : sortDir === 'asc' ? '↑' : '↓'}
+                              </span>
+                            </button>
+                          </th>
+                        );
+                      })}
                     </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
+                  </thead>
+                  <tbody>
+                    {pageRows.map((r, i) => (
+                      <tr key={`${r.stack}-${startIdx + i}`}>
+                        <td>{r.stack}</td>
+                        <td>{fmtNumber(r.p50, 0)}</td>
+                        <td>{fmtInt(r.n)}</td>
+                      </tr>
+                    ))}
 
-            {/* footer: pagination */}
-            {total > 0 && (
-              <div className={styles.pager}>
-                <div className={styles.pager__stats}>
-                  Showing <strong>{fmtInt(total === 0 ? 0 : startIdx + 1)}</strong>–
-                  <strong>{fmtInt(endIdx)}</strong> of <strong>{fmtInt(total)}</strong>
-                </div>
-
-                <div className={styles.pager__controls}>
-                  <button
-                    type="button"
-                    className={styles.pager__btn}
-                    onClick={() => canPrev && setPage((p) => Math.max(1, p - 1))}
-                    disabled={!canPrev}
-                    aria-label="Previous page"
-                  >
-                    ‹ Prev
-                  </button>
-
-                  <span className={styles.pager__page}>
-                    Page {page} / {totalPages}
-                  </span>
-
-                  <button
-                    type="button"
-                    className={styles.pager__btn}
-                    onClick={() => canNext && setPage((p) => Math.min(totalPages, p + 1))}
-                    disabled={!canNext}
-                    aria-label="Next page"
-                  >
-                    Next ›
-                  </button>
-
-                  <label className={styles.pager__size}>
-                    Rows per page
-                    <select value={pageSize} onChange={(e) => setPageSize(Number(e.target.value))}>
-                      {PAGE_SIZES.map((n) => (
-                        <option key={n} value={n}>
-                          {n}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                </div>
+                    {total === 0 && (
+                      <tr>
+                        <td colSpan={3} className={styles.dashboard__tableEmpty}>
+                          No data available. Upload a dataset to see results.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
               </div>
-            )}
-          </section>
-        </>
-      )}
+
+              {/* footer: pagination */}
+              {total > 0 && (
+                <div className={styles.dashboard__pager}>
+                  <div className={styles.dashboard__pagerStats}>
+                    Showing <strong>{fmtInt(total === 0 ? 0 : startIdx + 1)}</strong>–
+                    <strong>{fmtInt(endIdx)}</strong> of <strong>{fmtInt(total)}</strong>
+                  </div>
+
+                  <div className={styles.dashboard__pagerControls}>
+                    <button
+                      type="button"
+                      className={styles.dashboard__pagerBtn}
+                      onClick={() => canPrev && setPage((p) => Math.max(1, p - 1))}
+                      disabled={!canPrev}
+                      aria-label="Previous page"
+                    >
+                      ‹ Prev
+                    </button>
+
+                    <span className={styles.dashboard__pagerPage}>
+                      {page} / {totalPages}
+                    </span>
+
+                    <button
+                      type="button"
+                      className={styles.dashboard__pagerBtn}
+                      onClick={() => canNext && setPage((p) => Math.min(totalPages, p + 1))}
+                      disabled={!canNext}
+                      aria-label="Next page"
+                    >
+                      Next ›
+                    </button>
+
+                    <label className={styles.dashboard__pagerSize}>
+                      Rows
+                      <select value={pageSize} onChange={(e) => setPageSize(Number(e.target.value))}>
+                        {PAGE_SIZES.map((n) => (
+                          <option key={n} value={n}>
+                            {n}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/UploadWizard/UploadWizard.module.scss
+++ b/frontend/src/pages/UploadWizard/UploadWizard.module.scss
@@ -1,10 +1,184 @@
 .uploadWizard {
-  display: flex;
-  flex-direction: column;
-  padding: var(--space-4);
+  padding: var(--space-5) 0;
 
-  &__fileUpload {
-    margin-bottom: var(--space-6);
-    color: var(--color-dark-grey);
+  &__container {
+    max-width: 720px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+
+  // ── Page header ────────────────────────────────────────
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  &__eyebrow {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-primary);
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1.2;
+    color: var(--color-text);
+  }
+
+  &__subtitle {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--color-muted);
+    line-height: 1.5;
+  }
+
+  // ── Step indicators ────────────────────────────────────
+  &__steps {
+    display: flex;
+    align-items: center;
+  }
+
+  &__step {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    opacity: 0.4;
+    transition: opacity 0.2s;
+
+    &--active {
+      opacity: 1;
+    }
+
+    &--done {
+      opacity: 0.7;
+    }
+  }
+
+  &__stepDivider {
+    flex: 1;
+    height: 1px;
+    background: #e5e7eb;
+    min-width: var(--space-4);
+  }
+
+  &__stepNum {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid #d1d5db;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #9ca3af;
+    flex-shrink: 0;
+    transition: background 0.2s, border-color 0.2s, color 0.2s;
+
+    .uploadWizard__step--active & {
+      border-color: var(--color-primary);
+      color: var(--color-primary);
+    }
+
+    .uploadWizard__step--done & {
+      background: var(--color-primary);
+      border-color: var(--color-primary);
+      color: #fff;
+    }
+  }
+
+  &__stepLabel {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #9ca3af;
+    white-space: nowrap;
+
+    .uploadWizard__step--active & {
+      color: var(--color-text);
+      font-weight: 600;
+    }
+
+    .uploadWizard__step--done & {
+      color: var(--color-muted);
+    }
+  }
+
+  // ── Content cards ──────────────────────────────────────
+  &__card {
+    background: var(--color-surface);
+    border: 1px solid #e5e7eb;
+    border-radius: var(--radius-2);
+    padding: var(--space-5);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  &__sectionHeader {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__sectionTitle {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  &__sectionHint {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-muted);
+  }
+
+  // ── File success badge ─────────────────────────────────
+  &__fileSuccess {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    background: #f0fdf4;
+    border: 1px solid #bbf7d0;
+    border-radius: var(--radius-2);
+  }
+
+  &__fileSuccessIcon {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #dcfce7;
+    color: var(--color-success);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    font-weight: 700;
+    flex-shrink: 0;
+    line-height: 1;
+  }
+
+  &__fileSuccessTitle {
+    margin: 0 0 4px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--color-text);
+  }
+
+  &__fileId {
+    display: block;
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: var(--color-muted);
+    word-break: break-all;
   }
 }

--- a/frontend/src/pages/UploadWizard/UploadWizard.tsx
+++ b/frontend/src/pages/UploadWizard/UploadWizard.tsx
@@ -1,34 +1,89 @@
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import styles from './UploadWizard.module.scss';
 import FileUpload from '../../components/FileUpload/FileUpload';
 import ColumnMapForm from '../../components/ColumnMapForm/ColumnMapForm';
 import TaskStatus from '../../components/TaskStatus/TaskStatus';
 
+const STEPS = [
+  { n: 1, label: 'Upload file' },
+  { n: 2, label: 'Map columns' },
+  { n: 3, label: 'Processing' },
+];
+
 function UploadWizard() {
   const [fileId, setFileId] = useState<string | null>(null);
   const [taskId, setTaskId] = useState<string | null>(null);
 
+  const currentStep = taskId ? 3 : fileId ? 2 : 1;
+
   return (
     <div className={styles.uploadWizard}>
-      <h2>Upload Wizard</h2>
+      <div className={styles.uploadWizard__container}>
+        <header className={styles.uploadWizard__header}>
+          <span className={styles.uploadWizard__eyebrow}>Data import</span>
+          <h2 className={styles.uploadWizard__title}>Upload Wizard</h2>
+          <p className={styles.uploadWizard__subtitle}>
+            Upload salary datasets, map columns, and start analytics processing.
+          </p>
+        </header>
 
-      <div className={styles.uploadWizard__fileUpload}>
-        {!fileId && <FileUpload onUploaded={setFileId} />}
-        {fileId && (
-          <div>
-            <strong>File ID:</strong> {fileId}
+        <div className={styles.uploadWizard__steps}>
+          {STEPS.map(({ n, label }, i) => (
+            <Fragment key={n}>
+              {i > 0 && <div className={styles.uploadWizard__stepDivider} />}
+              <div
+                className={[
+                  styles.uploadWizard__step,
+                  currentStep === n ? styles['uploadWizard__step--active'] : '',
+                  currentStep > n ? styles['uploadWizard__step--done'] : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <span className={styles.uploadWizard__stepNum}>{n}</span>
+                <span className={styles.uploadWizard__stepLabel}>{label}</span>
+              </div>
+            </Fragment>
+          ))}
+        </div>
+
+        <div className={styles.uploadWizard__card}>
+          {!fileId ? (
+            <FileUpload onUploaded={setFileId} />
+          ) : (
+            <div className={styles.uploadWizard__fileSuccess}>
+              <span className={styles.uploadWizard__fileSuccessIcon}>✓</span>
+              <div>
+                <p className={styles.uploadWizard__fileSuccessTitle}>File uploaded successfully</p>
+                <code className={styles.uploadWizard__fileId}>{fileId}</code>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {fileId && !taskId && (
+          <div className={styles.uploadWizard__card}>
+            <div className={styles.uploadWizard__sectionHeader}>
+              <h3 className={styles.uploadWizard__sectionTitle}>Map columns</h3>
+              <p className={styles.uploadWizard__sectionHint}>
+                Match your CSV column names to the expected fields.
+              </p>
+            </div>
+            <ColumnMapForm fileId={fileId} onMapped={setTaskId} />
           </div>
         )}
-      </div>
 
-      <hr />
-
-      <div className={styles.uploadWizard__columnMap}>
-        {fileId && !taskId && <ColumnMapForm fileId={fileId} onMapped={setTaskId} />}
-      </div>
-
-      <div className={styles.uploadWizard__taskStatus}>
-        {taskId && <TaskStatus taskId={taskId} />}
+        {taskId && (
+          <div className={styles.uploadWizard__card}>
+            <div className={styles.uploadWizard__sectionHeader}>
+              <h3 className={styles.uploadWizard__sectionTitle}>Processing</h3>
+              <p className={styles.uploadWizard__sectionHint}>
+                Your dataset is being ingested. This may take a moment.
+              </p>
+            </div>
+            <TaskStatus taskId={taskId} />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Visual refresh across the three main frontend surfaces: Dashboard gets
column sorting; UploadWizard gets a step progress indicator and card layout;
FileUpload gets a dropzone redesign. Also fixes a toast bug where success
toast fired even on upload errors.

## Changes

- `Dashboard.tsx`: sortable columns (stack/p50/n), click to toggle direction, resets page on sort
- `Dashboard.module.scss`: layout refresh to match new table structure
- `UploadWizard.tsx`: step progress indicator (Upload → Map Columns → Processing), card layout, file-success display
- `UploadWizard.module.scss`: step indicator, card, and file-success styles
- `FileUpload.tsx`: dropzone redesign with upload icon; fix toast.success moved from `finally` to success path only
- `FileUpload.module.scss`: BEM dropzone, icon, title, and hint styles

## Validation

- Not run. Suggested: `make lint-frontend && make typecheck-frontend`
- Manual: upload a file → wizard steps advance correctly
- Manual: dashboard table sorts on column header click
- Manual: upload error shows error toast only, not success toast

## Notes for reviewers

No backend or API contract changes. Frontend state only.